### PR TITLE
use autoload

### DIFF
--- a/autoload/openurl.vim
+++ b/autoload/openurl.vim
@@ -1,0 +1,21 @@
+ruby << EOF
+  def open_url
+    re = %r{(?i)\b((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\))+(?:\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))}
+
+    line = VIM::Buffer.current.line
+    urls = line.scan(re).flatten
+
+    if urls.empty?
+      VIM::message("No URL found in line.")
+    else
+      system(VIM::evaluate("g:open_url_browser"), *urls)
+      VIM::message(urls.join(" and "))
+    end
+  end
+EOF
+
+function! openurl#OpenURL()
+  ruby open_url
+endfunction
+
+

--- a/plugin/open_url.vim
+++ b/plugin/open_url.vim
@@ -1,11 +1,6 @@
 if exists("g:loaded_open_url")
   finish
 endif
-let g:loaded_open_url = 1
-
-if !exists("g:open_url_browser")
-    let g:open_url_browser="open"
-endif
 
 if !has("ruby")
   echohl ErrorMsg
@@ -13,27 +8,13 @@ if !has("ruby")
   finish
 end
 
-ruby << EOF
-  def open_url
-    re = %r{(?i)\b((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\))+(?:\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))}
+let g:loaded_open_url = 1
 
-    line = VIM::Buffer.current.line
-    urls = line.scan(re).flatten
+if !exists("g:open_url_browser")
+    let g:open_url_browser="open"
+endif
 
-    if urls.empty?
-      VIM::message("No URL found in line.")
-    else
-      system(VIM::evaluate("g:open_url_browser"), *urls)
-      VIM::message(urls.join(" and "))
-    end
-  end
-EOF
-
-function! s:OpenURL()
-  ruby open_url
-endfunction
-
-command! -range OpenURL execute '<line1>,<line2>call <SID>OpenURL()'
+command! -range OpenURL execute '<line1>,<line2>call openurl#OpenURL()'
 
 if !hasmapto('OpenURL')
   map <leader>u :OpenURL<CR>


### PR DESCRIPTION
Hi Henrik,

While using an old computer I decided to profile my vim startup as it was very slow ...
Doing so I realized that vim-open-url was taking almost 0.2 seconds at startup which seems to be a lot for a small plugin, so I moved the ruby stuff to an autoload file reducing the startup time to 0.0007 seconds.

Before:

```
SCRIPT  /home/david/.vim/bundle/vim-open-url/plugin/open_url.vim
Sourced 1 time
Total time:   0.186361
 Self time:   0.186361
```

After:

```
SCRIPT  /home/david/.vim/bundle/vim-open-url/plugin/open_url.vim
Sourced 1 time
Total time:   0.000638
 Self time:   0.000638
```

What do you think about this ?

David

P.S: I also moved some initializations after the ruby existence test.
